### PR TITLE
Feat: Update Dockerfile

### DIFF
--- a/movies-front/Dockerfile
+++ b/movies-front/Dockerfile
@@ -6,4 +6,4 @@ COPY package.json .
 
 RUN npm install --quiet
 
-COPY . ..
+COPY . .


### PR DESCRIPTION
Se modifica archivo Dockerfile de movies-front, `COPY . ..` por `COPY . .`, ya que copia el código en una carpeta superior a la que van a estar la carpeta node_modules. 

Por lo tanto, se sugiere corregir el Dockerfile del movies-front  para que se pueda ejecutar el comando `npm start` descrito en el archivo README.md